### PR TITLE
Refactor models to use class syntax

### DIFF
--- a/models/department.js
+++ b/models/department.js
@@ -1,22 +1,29 @@
 /********************************************************/
 // Model Imports
 var Model = require('./model');
+var User = require('./user');
+var Project = require('./project');
 /********************************************************/
 
+class Department extends Model {
+    constructor(department) {
+        super();
+        this.id = department.id;
+        this.name = department.name;
+        this.userId = department.user_id;
+    }
 
-var Department = function(department) {
-    this.id = department.id;
-    this.name = department.name;
-    this.userId = department.user_id;
+    employees() {
+        return this.hasMany(User);
+    }
+
+    manager() {
+        return this.belongsTo(User);
+    }
+
+    projects() {
+        return this.hasMany(Project);
+    }
 }
-
-// Get prototype methods from Model
-Department.prototype = new Model;
-
-//Set constructor for reference in Model functions
-Department.prototype.constructor = Department;
-
-// Get static methods from Model
-Object.assign(Department, Model);
 
 module.exports = Department;

--- a/models/model.js
+++ b/models/model.js
@@ -21,210 +21,193 @@ var snakeCase = require('../util/functions/snake-case');
  ****************************************************************************************************/
 
 
-/**
- * Dyanmic Model Constructor
- */
-var Model = function () {
-    this.query = '';
-}
+class Model {
 
-/***************************
- * Dynamic Model Methods
- ***************************/
-Model.prototype.hasMany = function (model) {
-    return model.where(`${this.constructor.name.toLowerCase()}_id`, this.id);
-}
+    constructor() {
+        this.query = '';
+    }
 
-Model.prototype.belongsTo = function (model) {
-    return model.where('id', this[`${model.name.toLowerCase()}Id`]).limit(1);
-}
+    /***************************
+     * Dynamic Model Methods
+     ***************************/
 
-/************************
- * Static Properties
- *************************/
+    hasOne(model) {
+        return model.where(`${this.constructor.name.toLowerCase()}_id`, this.id).limit(1);
+    }
 
-/**
- * Query is used for building the query string when using static methods.
- */
-Model.query = '';
+    hasMany(model) {
+        return model.where(`${this.constructor.name.toLowerCase()}_id`, this.id);
+    }
+
+    belongsTo(model) {
+        return model.where('id', this[`${model.name.toLowerCase()}Id`]).limit(1);
+    }
 
 
+    /*************************
+     * Static Methods
+     *************************/
 
-/*************************
- * Static Methods
- *************************/
+    /**
+     * select() is used to add the select clause to the query string
+     * pass in an array of fields for the model being queried
+     * 
+     * this function does execute the query, has to followd by get()
+     * 
+     * @param {array} fields | optional
+     * 
+     * @return {object}
+     */
+    static select(fields) {
+        this.query = 'SELECT ';
 
-/**
- * select() is used to add the select clause to the query string
- * pass in an array of fields for the model being queried
- * 
- * this function does execute the query, has to followd by get()
- * 
- * @param {array} fields | optional
- * 
- * @return {object}
- */
-Model.select = function (fields) {
-    this.query = 'SELECT ';
+        if (!fields || fields.length == 0) {
+            this.query += '* ';
+        } else {
+            fields.forEach(function (field, index) {
+                if (index == fields.length - 1) {
+                    this.query += `${field} `;
+                } else {
+                    this.query += `${field}, `;
+                }
+            }, this);
+        }
 
-    if (!fields || fields.length == 0) {
-        this.query += '* ';
-    } else {
-        fields.forEach(function (field, index) {
-            if (index == fields.length - 1) {
-                this.query += `${field} `;
+        this.query += `FROM ${snakeCase(this.name)}s`;
+
+        return this;
+    }
+
+    /**
+     * where() adds the where clause to the query string
+     * will automatically add a select * clause to query string if not already added
+     * 
+     * returns `this` for function chaining
+     * 
+     * @param {string} column | required
+     * @param {enum} operator | defaults to `=`
+     * @param {any} value     | required
+     * 
+     * @return {object}
+     */
+    static where(column, operator, value) {
+        if (!this.query.includes('SELECT')) {
+            this.query = `SELECT * FROM ${snakeCase(this.name)}s`;
+        }
+
+        this.query += ` WHERE ${column} `;
+
+        if (operators.includes(operator)) {
+            this.query += `${operator} ${value}`;
+        } else {
+            value = operator;
+            this.query += `= ${value}`;
+        }
+
+        return this;
+    }
+
+
+    /**
+     * limit() adds the limit clause to the query string
+     * will automatically add a select * clause to query string if not already added
+     * 
+     * returns `this` for function chaining
+     * 
+     * @param {number} limit | required
+     * 
+     * @return {object}
+     */
+    static limit(limit) {
+        if (!this.query.includes('SELECT')) {
+            this.query = `SELECT * FROM ${snakeCase(this.name)}s`;
+        }
+
+        this.query += ` LIMIT ${limit}`;
+
+        return this;
+    }
+
+
+    /**
+     * get() is the execution function for the query
+     * must be called at the end of every query build
+     * will automatically add the select * clause to query if not already added 
+     * 
+     * @return {array} hydrated results, typeof calling model
+     */
+    static async get(instance = false) {
+        if (!this.query.includes('SELECT')) {
+            this.query = `SELECT * FROM ${snakeCase(this.name)}s`;
+        }
+        
+        try {
+            var result = await pool.query(this.query);
+        } catch (err) {
+            throw err;
+        } 
+
+        this.query = '';
+
+        return instance ? this.hydrate(result.rows)[0] : this.hydrate(result.rows);
+    }
+
+
+    static first() {
+        return this.get(true);
+    }
+
+
+    /**
+     * create() is used to store a new tuple of the calling models type
+     * 
+     * tuple is an object composed of all the necessary key => value pairs to create a new tuple in db
+     * tuple key names will be automatically converted from camelCase to snake_case to be aligned with database attribute names
+     * 
+     * @return {object} single hydrated model from tuple, typeof calling model
+     */
+    static async create(tuple) {
+        let keys = Object.keys(tuple).map(key => snakeCase(key)).join(', ');
+        let values = Object.values(tuple).map(function (value) {
+            if (typeof value === 'string') {
+                return `'${value}'`;
             } else {
-                this.query += `${field}, `;
+                return value
             }
+        }).join(', ');
+
+        this.query = `INSERT INTO ${snakeCase(this.name)}s (${keys}) VALUES (${values}) RETURNING *`;
+
+        try {
+            var result = await pool.query(this.query);
+        } catch (err) {
+            throw err;
+        }
+
+        this.query = '';
+
+        return this.hydrate(result.rows)[0];
+    }
+
+
+    /**
+     * hydrate() is used to query results into named and functional objects of the correct type
+     * 
+     * @param {array} objects
+     */
+    static hydrate(objects) {
+        return objects.map(function (object) {
+            return new this(object);
         }, this);
     }
-
-    this.query += `FROM ${snakeCase(this.name)}s`;
-
-    return this;
 }
 
 
 /**
- * where() adds the where clause to the query string
- * will automatically add a select * clause to query string if not already added
- * 
- * returns `this` for function chaining
- * 
- * @param {string} column | required
- * @param {enum} operator | defaults to `=`
- * @param {any} value     | required
- * 
- * @return {object}
+ * Initialize static query property
+ * used in the static functions when building queries
  */
-Model.where = function (column, operator, value) {
-    if (!this.query.includes('SELECT')) {
-        this.query = `SELECT * FROM ${snakeCase(this.name)}s`;
-    }
-
-    this.query += ` WHERE ${column} `;
-
-    if (operators.includes(operator)) {
-        this.query += `${operator} ${value}`;
-    } else {
-        value = operator;
-        this.query += `= ${value}`;
-    }
-
-    return this;
-}
-
-/**
- * limit() adds the limit clause to the query string
- * will automatically add a select * clause to query string if not already added
- * 
- * returns `this` for function chaining
- * 
- * @param {number} limit | required
- * 
- * @return {object}
- */
-Model.limit = function (limit) {
-    if (!this.query.includes('SELECT')) {
-        this.query = `SELECT * FROM ${snakeCase(this.name)}s`;
-    }
-
-    this.query += ` LIMIT ${limit}`;
-
-    return this;
-}
-
-/**
- * get() is the execution function for the query
- * must be called at the end of every query build
- * will automatically add the select * clause to query if not already added 
- * 
- * @return {array} hydrated results, typeof calling model
- */
-Model.get = async function (instance = false) {
-    if (!this.query.includes('SELECT')) {
-        this.query = `SELECT * FROM ${snakeCase(this.name)}s`;
-    }
-    
-    try {
-        var result = await pool.query(this.query);
-    } catch (err) {
-        throw err;
-    } 
-
-    this.query = '';
-
-    return instance ? this.hydrate(result.rows)[0] : this.hydrate(result.rows);
-}
-
-Model.first = function () {
-    return this.get(true);
-}
-
-/**
- * create() is used to store a new tuple of the calling models type
- * 
- * tuple is an object composed of all the necessary key => value pairs to create a new tuple in db
- * tuple key names will be automatically converted from camelCase to snake_case to be aligned with database attribute names
- * 
- * @return {object} single hydrated model from tuple, typeof calling model
- */
-Model.create = async function (tuple) {
-    let keys = Object.keys(tuple).map(key => snakeCase(key)).join(', ');
-    let values = Object.values(tuple).map(function (value) {
-        if (typeof value === 'string') {
-            return `'${value}'`;
-        } else {
-            return value
-        }
-    }).join(', ');
-
-    this.query = `INSERT INTO ${snakeCase(this.name)}s (${keys}) VALUES (${values}) RETURNING *`;
-
-    try {
-        var result = await pool.query(this.query);
-    } catch (err) {
-        throw err;
-    }
-
-    return this.hydrate(result.rows)[0];
-}
-
-
-/**
- ************************* DEPRECATED ***********************************
- * promise() is used to build the generic promise wrapper for database queries
- * 
- * @param {string} query     | required
- * @param {function} hydrate | required
- * IMPORTANT: hydrate must be bound to the `this` object before being passed into Promise
- * EX: var hydrate = this.hydrate.bind(this)
- *     const p = this.promise(query, hydrate);
- */
-Model.promise = function (query, hydrate) {
-    return new Promise(function (resolve, reject) {
-        pool.query(query, function (err, result) {
-            if (err) {
-                reject(err);
-                return;
-            }
-
-            resolve(hydrate(result.rows));
-        });
-    });
-}
-
-/**
- * hydrate() is used to query results into named and functional objects of the correct type
- * 
- * @param {array} objects
- */
-Model.hydrate = function (objects) {
-    return objects.map(function (object) {
-        return new this(object);
-    }, this);
-}
-
+Model.query = '';
 
 
 

--- a/models/project.js
+++ b/models/project.js
@@ -1,23 +1,42 @@
 /********************************************************/
 // Model Imports
 var Model = require('./model');
+var Department = require('./department');
+var Task = require('./task');
+var TimeBlock = require('./time-block');
+var User = require('./user');
 /********************************************************/
 
 
-var Project = function (project) {
-    this.id = project.id;
-    this.name = project.name;
-    this.description = project.description;
-    this.budget = project.budget
-    this.dueDate = project.due_date;
-    this.userId = project.user_id;
-    this.projectId = project.department_id;
+class Project extends Model {
+    constructor() {
+        super();
+        this.id = project.id;
+        this.name = project.name;
+        this.description = project.description;
+        this.budget = project.budget
+        this.dueDate = project.due_date;
+        this.userId = project.user_id;
+        this.projectId = project.department_id;   
+    }
+
+    department() {
+        return this.belongsTo(Department);
+    }
+
+    manager() {
+        return this.belongsTo(User);
+    }
+
+    tasks() {
+        return this.hasMany(Task);
+    }
+
+    time() {
+        return this.hasMany(TimeBlock);
+    }
 }
 
-Project.prototype = new Model;
 
-Project.prototype.constructor = Project;
-
-Object.assign(Project, Model);
 
 module.exports = Project;

--- a/models/task.js
+++ b/models/task.js
@@ -1,22 +1,36 @@
 /********************************************************/
 // Model Imports
 var Model = require('./model');
+var Project = require('./project');
+var TimeBlock = require('./time-block');
+var User = require('./user');
 /********************************************************/
 
 
-var Task = function(task) {
-    this.id = task.id;
-    this.name = task.name;
-    this.description = task.description;
-    this.dueDate = task.due_date;
-    this.userId = task.user_id;
-    this.projectId = task.project_id;
+class Task extends Model {
+    constructor() {
+        super();
+        this.id = task.id;
+        this.name = task.name;
+        this.description = task.description;
+        this.dueDate = task.due_date;
+        this.userId = task.user_id;
+        this.projectId = task.project_id;      
+    }
+
+    project() {
+        return this.belongsTo(Project);
+    }
+
+    assignedTo() {
+        return this.belongsTo(User);
+    }
+
+    time() {
+        return this.hasMany(TimeBlock);
+    }
 }
 
-Task.prototype = new Model;
 
-Task.prototype.constructor = Task;
-
-Object.assign(Task, Model);
 
 module.exports = Task;

--- a/models/time-block.js
+++ b/models/time-block.js
@@ -1,23 +1,37 @@
 /********************************************************/
 // Model Imports
 var Model = require('./model');
+var Project = require('./project');
+var Task = require('./task');
+var User = require('./user');
 /********************************************************/
 
 
-var TimeBlock = function (timeBlock) {
-    this.id = timeBlock.id;
-    this.userId = timeBlock.user_id;
-    this.taskId = timeBlock.task_id;
-    this.projectId = timeBlock.project_id;
-    this.startTime = new Date(timeBlock.start_time);
-    this.endTime = new Date(timeBlock.end_time);
-    this.duration = this.endTime.getTime() - this.startTime.getTime();
+class TimeBlock extends Model {
+    constructor() {
+        super();
+        this.id = timeBlock.id;
+        this.userId = timeBlock.user_id;
+        this.taskId = timeBlock.task_id;
+        this.projectId = timeBlock.project_id;
+        this.startTime = new Date(timeBlock.start_time);
+        this.endTime = new Date(timeBlock.end_time);
+        this.duration = this.endTime.getTime() - this.startTime.getTime();
+    }
+
+    user() {
+        return this.belongsTo(User);
+    }
+
+    project() {
+        return this.belongsTo(Project);
+    }
+
+    task() {
+        return this.belongsTo(Task);
+    }
 }
 
-TimeBlock.prototype = new Model;
 
-TimeBlock.prototype.constructor = TimeBlock;
-
-Object.assign(TimeBlock, Model);
 
 module.exports = TimeBlock;

--- a/models/user.js
+++ b/models/user.js
@@ -6,31 +6,41 @@ var hash = require('../util/functions/hash');
 var Model = require('./model');
 var Project = require('./project');
 var Department = require('./department');
+var Task = require('./task');
+var TimeBlock = require('./time-block');
 /********************************************************/
 
+class User extends Model {
+    constructor(user) {
+        super();
+        this.id = user.id;
+        this.name = user.name;
+        this.email = user.email;
+        this.payRate = user.pay_rate;
+        this.admin = user.admin;
+        this.departmentId = user.department_id;
+    }
 
-var User = function (user) {
-    this.id = user.id;
-    this.name = user.name;
-    this.email = user.email;
-    this.payRate = user.pay_rate;
-    this.admin = user.admin;
-    this.departmentId = user.department_id;
+    department() {
+        return this.belongsTo(Department);
+    }
+
+    manages() {
+        return this.hasOne(Department);
+    }
+
+    projects() {
+        return this.hasMany(Project);
+    }
+
+    tasks() {
+        return this.hasMany(Task);
+    }
+
+    worked() {
+        return this.hasMany(TimeBlock);
+    }
 }
 
-User.prototype = new Model;
-
-User.prototype.constructor = User;
-
-Object.assign(User, Model);
-
-
-User.prototype.projects = function () {
-    return this.hasMany(Project);
-}
-
-User.prototype.department = function () {
-    return this.belongsTo(Department);
-}
 
 module.exports = User;


### PR DESCRIPTION
This pull request builds on the refactoring from merge [7ee0ac6](https://github.com/Database3380/ProjectManager/commit/7ee0ac650c2d2ffd4e90ec4db8351b9aefa646df) to increase readability of the model structure.

**Requires the container rebuild from the previous merge to be completed, these changes need the latest version of node (v7.7.2) in container**

Important Changes:
- Base Model object now uses [Class Syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes)
- Static methods are now explicitly defined as [static](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes#Static_methods)
- Defined models now explicitly [extend](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes#Sub_classing_with_extends) the Model base class.
- Relationships between models are explicitly defined.